### PR TITLE
chore: Appstoreconnect patch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='tap-appstore',
       py_modules=['tap-appstore'],
       install_requires=[
           'singer-python==5.13.0',
-          'appstoreconnect==0.10.0',
+          'appstoreconnect==0.10.1',
           'pytz==2023.3',
           'python-dateutil>=2.8.2,<3.0.0',
           'tenacity==8.2.3'


### PR DESCRIPTION
appstoreconnect has a `0.10.1` version that relaxes the version requirement on `cryptography`, making it possible to install the latest version of cryptography instead of building the wheel for a `2.*` version.